### PR TITLE
WAF-38: Get image urls from product search query instead of refined product query for each item

### DIFF
--- a/src/api/fragments.ts
+++ b/src/api/fragments.ts
@@ -44,6 +44,12 @@ const ProductView = `
             inStock
             url
             urlKey
+            attributes(roles: ["visible_in_plp"]) {
+              label
+              name
+              roles
+              value
+            }
             images {
                 label
                 url

--- a/src/components/ProductItem/MockData.ts
+++ b/src/components/ProductItem/MockData.ts
@@ -71,6 +71,17 @@ export const sampleProductNoImage: Product = {
     new_to_date: null,
     created_at: null,
     updated_at: null,
+    attributes: [
+      {
+        label: "Bazaarvoice average rating",
+        name: "bv_rating_average",
+        roles: [
+            "visible_in_pdp",
+            "visible_in_plp"
+        ],
+        value: "4.500000"
+      },
+    ],
     price: {
       final: {
         amount: {
@@ -216,6 +227,17 @@ export const sampleProductDiscounted: Product = {
     meta_title: null,
     meta_keyword: null,
     meta_description: null,
+    attributes: [
+      {
+        label: "Bazaarvoice average rating",
+        name: "bv_rating_average",
+        roles: [
+            "visible_in_pdp",
+            "visible_in_plp"
+        ],
+        value: "4.500000"
+      },
+    ],
     images: [
       {
         url: 'http://master-7rqtwti-eragxvhtzr4am.us-4.magentosite.cloud/media/catalog/product/l/u/luma-yoga-brick.jpg',
@@ -388,6 +410,17 @@ export const sampleProductNotDiscounted: Product = {
     meta_title: null,
     meta_keyword: null,
     meta_description: null,
+    attributes: [
+      {
+        label: "Bazaarvoice average rating",
+        name: "bv_rating_average",
+        roles: [
+            "visible_in_pdp",
+            "visible_in_plp"
+        ],
+        value: "4.500000"
+      },
+    ],
     images: [
       {
         url: 'http://master-7rqtwti-eragxvhtzr4am.us-4.magentosite.cloud/media/catalog/product/l/u/luma-yoga-brick.jpg',

--- a/src/components/ProductItem/ProductItem.tsx
+++ b/src/components/ProductItem/ProductItem.tsx
@@ -24,7 +24,7 @@ import {
 import { SEARCH_UNIT_ID } from '../../utils/constants';
 import {
   generateOptimizedImages,
-  getProductImagesFromQuery,
+  getProductImagesFromAttribute,
   getProductImageURLs
 } from '../../utils/getProductImage';
 import { htmlStringDecode } from '../../utils/htmlStringDecode';
@@ -106,7 +106,7 @@ export const ProductItem: FunctionComponent<ProductProps> = ({
 
   const productImageArray = imagesFromRefinedProduct
     ? getProductImageURLs(imagesFromRefinedProduct ?? [], 2)
-    : getProductImagesFromQuery(item);
+    : getProductImagesFromAttribute(item);
     
   let optimizedImageArray: { src: string; srcset: any }[] = [];
 

--- a/src/components/ProductItem/ProductItem.tsx
+++ b/src/components/ProductItem/ProductItem.tsx
@@ -24,9 +24,11 @@ import {
 import { SEARCH_UNIT_ID } from '../../utils/constants';
 import {
   generateOptimizedImages,
-  getProductImageURLs,
+  getProductImagesFromQuery,
+  getProductImageURLs
 } from '../../utils/getProductImage';
 import { htmlStringDecode } from '../../utils/htmlStringDecode';
+import { isSportsWear } from '../../utils/productUtils';
 import { AddToCartButton } from '../AddToCartButton';
 import ImageHover from '../ImageHover';
 import { SwatchButtonGroup } from '../SwatchButtonGroup';
@@ -96,18 +98,6 @@ export const ProductItem: FunctionComponent<ProductProps> = ({
     setImagesFromRefinedProduct(data.refineProduct.images);
     setRefinedProduct(data);
   };
-  
-  /** TEMP FIX to show image of the first variant per product */
-  const loadProductImagesFromRefinedProduct = async (optionIds: string[], sku: string) => {
-    const data = await refineProduct(optionIds, sku);
-    setImagesFromRefinedProduct(data.refineProduct?.images);
-  };
-
-  if (!productView.images?.length && !imagesFromRefinedProduct){
-    const optionId = productView.options?.[0]?.values?.[0]?.id || '';
-    loadProductImagesFromRefinedProduct([optionId], productView.sku);
-  }
-  /** END TEMP FIX to show image of the first variant per product */
 
   const isSelected = (id: string) => {
     const selected = selectedSwatch ? selectedSwatch === id : false;
@@ -116,11 +106,8 @@ export const ProductItem: FunctionComponent<ProductProps> = ({
 
   const productImageArray = imagesFromRefinedProduct
     ? getProductImageURLs(imagesFromRefinedProduct ?? [], 2)
-    : getProductImageURLs(
-        productView.images ?? [],
-        2,
-        product.image?.url ?? undefined
-      );
+    : getProductImagesFromQuery(item);
+    
   let optimizedImageArray: { src: string; srcset: any }[] = [];
 
   if (optimizeImages) {
@@ -145,6 +132,7 @@ export const ProductItem: FunctionComponent<ProductProps> = ({
   const isGrouped = product?.__typename === 'GroupedProduct';
   const isGiftCard = product?.__typename === 'GiftCardProduct';
   const isConfigurable = product?.__typename === 'ConfigurableProduct';
+  const shouldShowAddToBagButton = isSportsWear(item) && (!screenSize.desktop || isHovering) && !showSizes;
 
   const onProductClick = () => {
     window.adobeDataLayer.push((dl: any) => {
@@ -360,10 +348,7 @@ export const ProductItem: FunctionComponent<ProductProps> = ({
               />
             )}
             <div className="add-to-cart-overlay absolute left-0 right-0 bottom-0 p-xsmall h-[56px]">
-              {!screenSize.desktop && !showSizes && <AddToCartButton onClick={handleAddToCart} />}
-              {isHovering && screenSize.desktop && !showSizes && (
-                <AddToCartButton onClick={handleAddToCart} />
-              )}
+              {shouldShowAddToBagButton && <AddToCartButton onClick={handleAddToCart} />}
               {showSizes && productView?.options?.map((swatches) => {
                 if (swatches.title === SWATCH_SIZE) {
                   const swatchItems: SwatchValues[] = (swatches.values ?? []).map((swatch) => ({

--- a/src/context/displayChange.tsx
+++ b/src/context/displayChange.tsx
@@ -46,10 +46,10 @@ const useSensor = () => {
 export const ResizeChangeContext = createContext({} as DisplayChangeContext);
 
 const getColumn = (screenSize: DisplayChange): number => {
-  if (screenSize.desktop) {
+  if (window.matchMedia('screen and (min-width: 1281px)').matches) {
     return PRODUCT_COLUMNS.desktop;
   }
-  if (screenSize.tablet) {
+  if (window.matchMedia('screen and (min-width: 768px) and (max-width: 1280px)').matches) {
     return PRODUCT_COLUMNS.tablet;
   }
   if (screenSize.mobile) {

--- a/src/types/interface.ts
+++ b/src/types/interface.ts
@@ -216,6 +216,12 @@ export interface Product {
     new_to_date: null | string;
     created_at: null | string;
     updated_at: null | string;
+    attributes: Array<{
+      label: string
+      name: string
+      roles: string[]
+      value: string
+    }>;
     price: {
       final: ProductViewPrice;
       regular: ProductViewPrice;

--- a/src/utils/getProductImage.ts
+++ b/src/utils/getProductImage.ts
@@ -108,7 +108,19 @@ const generateOptimizedImages = (
   return imageUrlArray;
 };
 
-function getProductImagesFromQuery(item: Product) {
+/*
+* New attribute i.e. "eds_images" for product images were introduced to get around catalog service sync issue
+* Ref: https://adobe-dx-support.slack.com/archives/C04CQH83BME/p1719261375238899
+*
+* Following steps are taken to get the images:
+* 1. Get the attribute id from the product options by selecting the first option
+* 2. Find the attribute with name "eds_images"
+* 3. Parse the value of the attribute
+* 4. Find the option with the same attribute id as found in step 1
+* 6. If the product is sports wear, get the images from the option with same the variant id as in product view options found in step 1.
+* 7. If the product is not sports wear, get the images from the first option.
+*/
+function getProductImagesFromAttribute(item: Product) {
   const { productView } = item;
   const attributeId = productView?.options?.[0].id;
   if (!attributeId) {
@@ -154,4 +166,4 @@ function getAbsoluteImageUrl(item: Product, urls: string[]) {
   });
 }
 
-export { generateOptimizedImages, getProductImageURLs, getProductImagesFromQuery };
+export { generateOptimizedImages, getProductImageURLs, getProductImagesFromAttribute };

--- a/src/utils/productUtils.ts
+++ b/src/utils/productUtils.ts
@@ -1,0 +1,33 @@
+import { Product } from '../types/interface';
+
+function isSportsWear(product: Product) {
+  const { productView } = product;
+  const department = productView?.attributes?.find(({ name }) => name === 'pim_department_name');
+  
+  return department?.value.includes('Sportswear');
+}
+
+function getColorSwatchesFromQuery(item: Product) {
+  if (isSportsWear(item)) {
+    return [];
+  }
+
+  const { productView } = item;
+  const attributeId = productView?.options?.[0].id;
+  const imageAttributes = productView?.attributes?.find(({ name }) => name === 'eds_images');
+  if (imageAttributes) {
+    const options = JSON.parse(imageAttributes.value);
+    const colorOption = options.find((option: any) => option.attribute_id === attributeId 
+      && option.attribute_type === 'visual' 
+      && option.show_swatches);
+    if (!colorOption) {
+      return [];
+    }
+
+    return colorOption.images;
+  }
+
+  return [];
+}
+
+export { isSportsWear, getColorSwatchesFromQuery };

--- a/src/utils/productUtils.ts
+++ b/src/utils/productUtils.ts
@@ -7,7 +7,20 @@ function isSportsWear(product: Product) {
   return department?.value.includes('Sportswear');
 }
 
-function getColorSwatchesFromQuery(item: Product) {
+/*
+* New attribute i.e. "eds_images" for product images were introduced to get around catalog service sync issue
+* Ref: https://adobe-dx-support.slack.com/archives/C04CQH83BME/p1719261375238899
+*
+* Following steps are taken to get the color swatches:
+* 1. If the product is sports wear, return an empty array since there are no color swatches for sports wear
+* 2. Get the attribute id from the product view options by selecting the first option
+* 3. Find the attribute with name "eds_images" in product view attributes
+* 4. Parse the value of the attribute
+* 5. Find the option with the same attribute id as found in step 1
+* 6. Validate if the option has the attribute type as "visual" and show_swatches is true
+* 7. If the above condition is met, return the image options
+*/
+function getColorSwatchesFromAttribute(item: Product) {
   if (isSportsWear(item)) {
     return [];
   }
@@ -30,4 +43,4 @@ function getColorSwatchesFromQuery(item: Product) {
   return [];
 }
 
-export { isSportsWear, getColorSwatchesFromQuery };
+export { isSportsWear, getColorSwatchesFromAttribute };


### PR DESCRIPTION
This PR fixes 
1. Performance issue by removed refined product query call and getting images from product search query based on new "eds_images" attribute
2. Show Add to bag button only for sportswear category
3. Fix columns for various viewports